### PR TITLE
Dynamic environment settings

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,8 +16,8 @@ looks at whether the number of appointments is greater than the previously seen
 amount and only then sends a tweet. It also only tweets after all three of the
 following criteria are met:
 
-1. A minimum appointment threshold is reached - default 10
-2. A minimum increase since the last check is reached - default 5
+1. A minimum appointment threshold is reached - default 20
+2. A minimum increase since the last check is reached - default 10
 3. Hasn't tweeted about this clinic within a certain amount of time - default
    30 minutes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,10 +13,19 @@ branches for development.
 At a high level, the bot is a collection of site scrapers that run on an
 interval and check for appointments. When a site shows appointments, the bot
 looks at whether the number of appointments is greater than the previously seen
-amount and only then sends a tweet. It also only tweets when a certain
-threshold of appointments is seen, currently set at 10. This keeps the number
-of Tweets down and ensures only significant appointment drops actually get
-sent, rather than tweeting every time there's a cancellation.
+amount and only then sends a tweet. It also only tweets after all three of the
+following criteria are met:
+
+1. A minimum appointment threshold is reached - default 10
+2. A minimum increase since the last check is reached - default 5
+3. Hasn't tweeted about this clinic within a certain amount of time - default
+   30 minutes
+
+This keeps the number of Tweets down and ensures only significant appointment
+drops actually get sent, rather than tweeting every time there's a
+cancellation. All of these are also configurable on a per-clinic basis by using
+the name of the clinic in an environment variable, e.g.
+`MA_IMMUNIZATIONS_TWEET_THRESHOLD`.
 
 The Ruby code is predominantly programmed in an object oriented style, with the
 main loop contained in [run.rb](run.rb) and all other modules available under
@@ -39,4 +48,11 @@ method which returns a list of `Clinic` objects and that will be called in
 [run.rb](run.rb). A `Clinic` represents a single location on a particular date,
 and encodes information about the site, the number of appointments found, and
 anything else needed to encode a message for it. `Clinic` objects receive
-dependencies via dependency injection so that they are loosely coupled.
+dependencies via dependency injection so that they are loosely coupled, and
+typically subclass from either the `BaseClinic` or `PharmacyClinic` classes.
+
+`PharmacyClinic` classes are a bit different in that they group all locations
+under a single "clinic" instance and treat each location with availability as
+one appointment. This is usually done when a site doesn't provide easy access
+to seeing individual appointments, such as CVS which only shows a binary yes/no
+for each store's availability.

--- a/README.md
+++ b/README.md
@@ -109,20 +109,13 @@ Additional configuration can be done with the following:
 
 ### Site specific configuration
 
-There are also some site specific configurations to allow for tweaking behavior
-at runtime without having to change the code:
-
-MaImmunizations configuration:
+All modules allow for site specific configuration by setting environment
+variables based on the module name. For example, to set MaImmunizations
+configuration, use:
 
 * MA_IMMUNIZATIONS_TWEET_THRESHOLD
 * MA_IMMUNIZATIONS_TWEET_INCREASE_NEEDED
 * MA_IMMUNIZATIONS_TWEET_COOLDOWN
-
-CVS and Vaccinespotter configuration:
-
-* PHARMACY_TWEET_THRESHOLD
-* PHARMACY_TWEET_INCREASE_NEEDED
-* PHARMACY_TWEET_COOLDOWN
 
 ## Contributing
 

--- a/lib/sites/acuity.rb
+++ b/lib/sites/acuity.rb
@@ -145,6 +145,10 @@ module Acuity
       @link = link
     end
 
+    def module_name
+      'ACUITY'
+    end
+
     def title
       "#{name} on #{date}"
     end

--- a/lib/sites/amesbury.rb
+++ b/lib/sites/amesbury.rb
@@ -17,6 +17,7 @@ module Amesbury
       else
         logger.info "[Amesbury] Scanning #{sites.length} sites"
         MaImmunizationsRegistrations.all_clinics(
+          'AMESBURY',
           BASE_URL,
           sites.map { |clinic_url| "https://registrations.#{clinic_url[0]}" },
           storage,

--- a/lib/sites/athena.rb
+++ b/lib/sites/athena.rb
@@ -164,6 +164,10 @@ module Athena
       @appointments = appointments
     end
 
+    def module_name
+      'ATHENA'
+    end
+
     def title
       "#{@location} on #{date}"
     end

--- a/lib/sites/base_clinic.rb
+++ b/lib/sites/base_clinic.rb
@@ -1,13 +1,9 @@
 require 'date'
 
 class BaseClinic
-  TWEET_THRESHOLD = 20 # minimum number to post
-  TWEET_INCREASE_NEEDED = 10
-  TWEET_COOLDOWN = 30 * 60 # 30 minutes
-
-  # Pharmacies treat 1 store = 1 appointment, so the thresholds are lower
-  PHARMACY_TWEET_THRESHOLD = 10
-  PHARMACY_TWEET_INCREASE_NEEDED = 5
+  DEFAULT_TWEET_THRESHOLD = 20 # minimum number to post
+  DEFAULT_TWEET_INCREASE_NEEDED = 10
+  DEFAULT_TWEET_COOLDOWN = 30 * 60 # 30 minutes
 
   def initialize(storage)
     @storage = storage
@@ -60,14 +56,30 @@ class BaseClinic
     }
   end
 
+  def module_prefix
+    @module_prefix ||= self.class.to_s.gsub(/::.*/, '').gsub(/(.)([A-Z])/, '\1_\2').upcase
+  end
+
+  def tweet_threshold
+    ENV["#{module_prefix}_TWEET_THRESHOLD"] || self.class::DEFAULT_TWEET_THRESHOLD
+  end
+
+  def tweet_cooldown
+    ENV["#{module_prefix}_TWEET_COOLDOWN"] || self.class::DEFAULT_TWEET_COOLDOWN
+  end
+
+  def tweet_increase_needed
+    ENV["#{module_prefix}_TWEET_INCREASE_NEEDED"] || self.class::DEFAULT_TWEET_INCREASE_NEEDED
+  end
+
   def has_not_posted_recently?
-    (Time.now - last_posted_time) > self.class::TWEET_COOLDOWN # 10 minutes
+    (Time.now - last_posted_time) > tweet_cooldown
   end
 
   def should_tweet?
     !link.nil? &&
-      appointments >= self.class::TWEET_THRESHOLD &&
-      new_appointments >= self.class::TWEET_INCREASE_NEEDED &&
+      appointments >= tweet_threshold &&
+      new_appointments >= tweet_increase_needed &&
       has_not_posted_recently?
   end
 

--- a/lib/sites/base_clinic.rb
+++ b/lib/sites/base_clinic.rb
@@ -56,20 +56,20 @@ class BaseClinic
     }
   end
 
-  def module_prefix
-    @module_prefix ||= self.class.to_s.gsub(/::.*/, '').gsub(/(.)([A-Z])/, '\1_\2').upcase
+  def module_name
+    'DEFAULT'
   end
 
   def tweet_threshold
-    ENV["#{module_prefix}_TWEET_THRESHOLD"] || self.class::DEFAULT_TWEET_THRESHOLD
+    ENV["#{module_name}_TWEET_THRESHOLD"] || self.class::DEFAULT_TWEET_THRESHOLD
   end
 
   def tweet_cooldown
-    ENV["#{module_prefix}_TWEET_COOLDOWN"] || self.class::DEFAULT_TWEET_COOLDOWN
+    ENV["#{module_name}_TWEET_COOLDOWN"] || self.class::DEFAULT_TWEET_COOLDOWN
   end
 
   def tweet_increase_needed
-    ENV["#{module_prefix}_TWEET_INCREASE_NEEDED"] || self.class::DEFAULT_TWEET_INCREASE_NEEDED
+    ENV["#{module_name}_TWEET_INCREASE_NEEDED"] || self.class::DEFAULT_TWEET_INCREASE_NEEDED
   end
 
   def has_not_posted_recently?

--- a/lib/sites/base_clinic.rb
+++ b/lib/sites/base_clinic.rb
@@ -61,15 +61,15 @@ class BaseClinic
   end
 
   def tweet_threshold
-    ENV["#{module_name}_TWEET_THRESHOLD"] || self.class::DEFAULT_TWEET_THRESHOLD
+    ENV["#{module_name}_TWEET_THRESHOLD"]&.to_i || self.class::DEFAULT_TWEET_THRESHOLD
   end
 
   def tweet_cooldown
-    ENV["#{module_name}_TWEET_COOLDOWN"] || self.class::DEFAULT_TWEET_COOLDOWN
+    ENV["#{module_name}_TWEET_COOLDOWN"]&.to_i || self.class::DEFAULT_TWEET_COOLDOWN
   end
 
   def tweet_increase_needed
-    ENV["#{module_name}_TWEET_INCREASE_NEEDED"] || self.class::DEFAULT_TWEET_INCREASE_NEEDED
+    ENV["#{module_name}_TWEET_INCREASE_NEEDED"]&.to_i || self.class::DEFAULT_TWEET_INCREASE_NEEDED
   end
 
   def has_not_posted_recently?

--- a/lib/sites/baystate_health.rb
+++ b/lib/sites/baystate_health.rb
@@ -75,6 +75,10 @@ module BaystateHealth
       @vaccines = Set.new
     end
 
+    def module_name
+      'BAYSTATE_HEALTH'
+    end
+
     def title
       'Baystate Health'
     end

--- a/lib/sites/color.rb
+++ b/lib/sites/color.rb
@@ -138,6 +138,10 @@ module Color
       @link = link
     end
 
+    def module_name
+      'COLOR'
+    end
+
     def name
       @site_info['name']
     end

--- a/lib/sites/costco.rb
+++ b/lib/sites/costco.rb
@@ -146,6 +146,10 @@ module Costco
       @appointment_data = appointment_data.sort_by { |client| client[:location] }
     end
 
+    def module_name
+      'COSTCO'
+    end
+
     def title
       'Costco'
     end

--- a/lib/sites/curative.rb
+++ b/lib/sites/curative.rb
@@ -91,6 +91,10 @@ module Curative
       @appointments = appointments
     end
 
+    def module_name
+      'CURATIVE'
+    end
+
     def name
       @json['name']
     end

--- a/lib/sites/cvs.rb
+++ b/lib/sites/cvs.rb
@@ -140,6 +140,10 @@ module Cvs
       @state_status_url = "https://www.cvs.com/immunizations/covid-19-vaccine.vaccine-status.#{state}.json?vaccineinfo".freeze
     end
 
+    def module_name
+      'CVS'
+    end
+
     def init_session(logger)
       @user_agent = @user_agents.sample
       headers = {

--- a/lib/sites/cvs.rb
+++ b/lib/sites/cvs.rb
@@ -2,7 +2,7 @@ require 'date'
 require 'json'
 require 'rest-client'
 
-require_relative './base_clinic'
+require_relative './pharmacy_clinic'
 
 module Cvs
   STATE = 'MA'.freeze
@@ -46,11 +46,8 @@ module Cvs
     clinics
   end
 
-  class StateClinic < BaseClinic
+  class StateClinic < PharmacyClinic
     LAST_SEEN_CITIES_KEY = 'cvs-last-cities'.freeze
-    TWEET_THRESHOLD = ENV['PHARMACY_TWEET_THRESHOLD']&.to_i || BaseClinic::PHARMACY_TWEET_THRESHOLD
-    TWEET_INCREASE_NEEDED = ENV['PHARMACY_TWEET_INCREASE_NEEDED']&.to_i || BaseClinic::PHARMACY_TWEET_INCREASE_NEEDED
-    TWEET_COOLDOWN = ENV['PHARMACY_TWEET_COOLDOWN']&.to_i || (60 * 60)
 
     def initialize(storage, cities, state)
       super(storage)

--- a/lib/sites/heywood_healthcare.rb
+++ b/lib/sites/heywood_healthcare.rb
@@ -70,6 +70,10 @@ module HeywoodHealthcare
       @link = link
     end
 
+    def module_name
+      'HEYWOOD_HEALTHCARE'
+    end
+
     def title
       "#{name} on #{date}"
     end

--- a/lib/sites/holyoke_health.rb
+++ b/lib/sites/holyoke_health.rb
@@ -144,6 +144,10 @@ module HolyokeHealth
       @appointments = appointments
     end
 
+    def module_name
+      'HOLYOKE_HEALTH'
+    end
+
     def title
       "#{location} on #{date}"
     end

--- a/lib/sites/lowell_general.rb
+++ b/lib/sites/lowell_general.rb
@@ -106,6 +106,10 @@ module LowellGeneral
       @appointments = appointments
     end
 
+    def module_name
+      'LOWELL_GENERAL'
+    end
+
     def title
       "#{name} on #{date}"
     end

--- a/lib/sites/ma_immunizations.rb
+++ b/lib/sites/ma_immunizations.rb
@@ -160,6 +160,10 @@ module MaImmunizations
       end
     end
 
+    def module_name
+      'MA_IMMUNIZATIONS'
+    end
+
     def valid?
       @parsed_info.key?('Available Appointments')
     end

--- a/lib/sites/ma_immunizations.rb
+++ b/lib/sites/ma_immunizations.rb
@@ -140,9 +140,6 @@ module MaImmunizations
 
   class Clinic < BaseClinic
     TITLE_MATCHER = %r[^(.+) on (\d{2}/\d{2}/\d{4})$].freeze
-    TWEET_THRESHOLD = ENV['MA_IMMUNIZATIONS_TWEET_THRESHOLD']&.to_i || BaseClinic::TWEET_THRESHOLD
-    TWEET_INCREASE_NEEDED = ENV['MA_IMMUNIZATIONS_TWEET_INCREASE_NEEDED']&.to_i || BaseClinic::TWEET_INCREASE_NEEDED
-    TWEET_COOLDOWN = ENV['MA_IMMUNIZATIONS_TWEET_COOLDOWN']&.to_i || BaseClinic::TWEET_COOLDOWN
 
     attr_accessor :appointments, :vaccines
 

--- a/lib/sites/ma_immunizations_registrations.rb
+++ b/lib/sites/ma_immunizations_registrations.rb
@@ -4,7 +4,7 @@ require 'nokogiri'
 require_relative './base_clinic'
 
 module MaImmunizationsRegistrations
-  def self.all_clinics(sign_up_page, pages, storage, logger, log_module, additional_info = nil)
+  def self.all_clinics(module_name, sign_up_page, pages, storage, logger, log_module, additional_info = nil)
     pages.each_with_object(Hash.new(0)) do |clinic_url, h|
       sleep(1)
       scrape_result = scrape_registration_site(logger, log_module, clinic_url)
@@ -12,7 +12,7 @@ module MaImmunizationsRegistrations
 
       h[[scrape_result[0], scrape_result[1]]] += scrape_result[2]
     end.map do |(title, vaccine), appointments|
-      Clinic.new(storage, title, sign_up_page, appointments, vaccine, additional_info)
+      Clinic.new(module_name, storage, title, sign_up_page, appointments, vaccine, additional_info)
     end
   end
 
@@ -66,10 +66,11 @@ module MaImmunizationsRegistrations
     DEFAULT_TWEET_INCREASE_NEEDED = 50
     DEFAULT_TWEET_COOLDOWN = 3600 # 1 hour
 
-    attr_reader :title, :link, :appointments, :vaccine
+    attr_reader :module_name, :title, :link, :appointments, :vaccine
 
-    def initialize(storage, title, link, appointments, vaccine, additional_info)
+    def initialize(mod_name, storage, title, link, appointments, vaccine, additional_info)
       super(storage)
+      @module_name = mod_name
       @title = title
       @link = link
       @appointments = appointments

--- a/lib/sites/ma_immunizations_registrations.rb
+++ b/lib/sites/ma_immunizations_registrations.rb
@@ -63,8 +63,8 @@ module MaImmunizationsRegistrations
 
   class Clinic < BaseClinic
     TITLE_MATCHER = %r[^(.+) on (\d{2}/\d{2}/\d{4})$].freeze
-    TWEET_INCREASE_NEEDED = 50
-    TWEET_COOLDOWN = 3600 # 1 hour
+    DEFAULT_TWEET_INCREASE_NEEDED = 50
+    DEFAULT_TWEET_COOLDOWN = 3600 # 1 hour
 
     attr_reader :title, :link, :appointments, :vaccine
 

--- a/lib/sites/my_chart.rb
+++ b/lib/sites/my_chart.rb
@@ -394,6 +394,10 @@ module MyChart
       @storage_key_prefix = storage_key_prefix
     end
 
+    def module_name
+      'MY_CHART'
+    end
+
     def name
       @department['Name']
     end

--- a/lib/sites/northampton.rb
+++ b/lib/sites/northampton.rb
@@ -17,6 +17,7 @@ module Northampton
       else
         logger.info "[Northampton] Scanning #{sites.length} sites"
         MaImmunizationsRegistrations.all_clinics(
+          'NORTHAMPTON',
           BASE_URL,
           sites.map { |clinic_url| "https://registrations.#{clinic_url[0]}" },
           storage,

--- a/lib/sites/pharmacy_clinic.rb
+++ b/lib/sites/pharmacy_clinic.rb
@@ -1,7 +1,7 @@
 require_relative './base_clinic'
 
 class PharmacyClinic < BaseClinic
-  DEFAULT_TWEET_THRESHOLD = 5
-  DEFAULT_TWEET_INCREASE_NEEDED = 2
-  DEFAULT_TWEET_COOLDOWN = 30 * 60 # 30 minutes
+  DEFAULT_TWEET_THRESHOLD = 10
+  DEFAULT_TWEET_INCREASE_NEEDED = 5
+  DEFAULT_TWEET_COOLDOWN = 60 * 60 # 1 hour
 end

--- a/lib/sites/pharmacy_clinic.rb
+++ b/lib/sites/pharmacy_clinic.rb
@@ -1,0 +1,7 @@
+require_relative './base_clinic'
+
+class PharmacyClinic < BaseClinic
+  DEFAULT_TWEET_THRESHOLD = 5
+  DEFAULT_TWEET_INCREASE_NEEDED = 2
+  DEFAULT_TWEET_COOLDOWN = 30 * 60 # 30 minutes
+end

--- a/lib/sites/rutland.rb
+++ b/lib/sites/rutland.rb
@@ -31,6 +31,7 @@ module Rutland
         else
           logger.info "[Rutland] Scanning #{sites.length} sites"
           MaImmunizationsRegistrations.all_clinics(
+            'RUTLAND',
             MAIN_URL,
             sites.map { |clinic_num| "https://registrations.maimmunizations.org//reg/#{clinic_num[0]}" },
             storage,
@@ -53,6 +54,7 @@ module Rutland
       else
         logger.info "[Rutland] Scanning #{sites.length} sites"
         MaImmunizationsRegistrations.all_clinics(
+          'RUTLAND',
           TEACHER_URL,
           sites.map { |clinic_num| "https://registrations.maimmunizations.org//reg/#{clinic_num[0]}" },
           storage,

--- a/lib/sites/rxtouch.rb
+++ b/lib/sites/rxtouch.rb
@@ -160,6 +160,10 @@ module Rxtouch
       @link = link
     end
 
+    def module_name
+      'RXTOUCH'
+    end
+
     def title
       @brand
     end

--- a/lib/sites/rxtouch.rb
+++ b/lib/sites/rxtouch.rb
@@ -1,8 +1,9 @@
 require 'rest-client'
 require 'nokogiri'
 
+require_relative '../user_agents'
 require_relative '../sentry_helper'
-require_relative './base_clinic'
+require_relative './pharmacy_clinic'
 
 module Rxtouch
   class Page
@@ -44,7 +45,7 @@ module Rxtouch
     def fetch_cookies
       cookies = {}
       12.times do
-        res = RestClient.get(sign_up_url, cookies: cookies)
+        res = RestClient.get(sign_up_url, cookies: cookies, user_agent: UserAgents.random)
         cookies = res.cookies
         return [true, cookies] unless res.request.url.include?('queue-it.net')
 
@@ -147,11 +148,8 @@ module Rxtouch
     end
   end
 
-  class Clinic < BaseClinic
+  class Clinic < PharmacyClinic
     LAST_SEEN_STORAGE_PREFIX = 'rxtouch-last-cities'.freeze
-    TWEET_THRESHOLD = ENV['PHARMACY_TWEET_THRESHOLD']&.to_i || BaseClinic::PHARMACY_TWEET_THRESHOLD
-    TWEET_INCREASE_NEEDED = ENV['PHARMACY_TWEET_INCREASE_NEEDED']&.to_i || BaseClinic::PHARMACY_TWEET_INCREASE_NEEDED
-    TWEET_COOLDOWN = ENV['PHARMACY_TWEET_COOLDOWN']&.to_i || BaseClinic::TWEET_COOLDOWN
 
     attr_reader :cities, :link
 
@@ -231,7 +229,7 @@ module Rxtouch
   end
 
   ALL_SITES = [
-    #StopAndShop,
+    StopAndShop,
     Hannaford,
   ].freeze
 

--- a/lib/sites/southcoast.rb
+++ b/lib/sites/southcoast.rb
@@ -90,6 +90,10 @@ module Southcoast
       @appointments = appointments
     end
 
+    def module_name
+      'SOUTHCOAST'
+    end
+
     def title
       "Southcoast Health in #{@site}, MA on #{date}"
     end

--- a/lib/sites/trinity_health.rb
+++ b/lib/sites/trinity_health.rb
@@ -56,6 +56,10 @@ module TrinityHealth
       @appointments = appointments
     end
 
+    def module_name
+      'TRINITY_HEALTH'
+    end
+
     def title
       "#{NAME} on #{date}"
     end

--- a/lib/sites/vaccinespotter.rb
+++ b/lib/sites/vaccinespotter.rb
@@ -64,6 +64,10 @@ module Vaccinespotter
       @stores = stores
     end
 
+    def module_name
+      'VACCINESPOTTER_PHARMACY'
+    end
+
     def cities
       @stores.map { |store| store['city'] }.compact.uniq.sort
     end
@@ -145,6 +149,10 @@ module Vaccinespotter
       super(storage)
       @brand = brand
       @stores = stores.sort_by { |store| store['city'] }
+    end
+
+    def module_name
+      'VACCINESPOTTER'
     end
 
     def title

--- a/lib/sites/vaccinespotter.rb
+++ b/lib/sites/vaccinespotter.rb
@@ -2,7 +2,7 @@ require 'rest-client'
 require 'json'
 
 require_relative '../sentry_helper'
-require_relative './base_clinic'
+require_relative './pharmacy_clinic'
 
 module Vaccinespotter
   API_URL = 'https://www.vaccinespotter.org/api/v0/states/MA.json'.freeze
@@ -55,11 +55,8 @@ module Vaccinespotter
     JSON.parse(RestClient.get(API_URL).body)
   end
 
-  class Clinic < BaseClinic
+  class Clinic < PharmacyClinic
     LAST_SEEN_STORAGE_PREFIX = 'vaccinespotter-last-cities'.freeze
-    TWEET_THRESHOLD = ENV['PHARMACY_TWEET_THRESHOLD']&.to_i || BaseClinic::PHARMACY_TWEET_THRESHOLD
-    TWEET_INCREASE_NEEDED = ENV['PHARMACY_TWEET_INCREASE_NEEDED']&.to_i || BaseClinic::PHARMACY_TWEET_INCREASE_NEEDED
-    TWEET_COOLDOWN = ENV['PHARMACY_TWEET_COOLDOWN']&.to_i || BaseClinic::TWEET_COOLDOWN
 
     def initialize(storage, brand, stores)
       super(storage)

--- a/lib/sites/walgreens.rb
+++ b/lib/sites/walgreens.rb
@@ -161,6 +161,10 @@ module Walgreens
       @cities = cities
     end
 
+    def module_name
+      'WALGREENS'
+    end
+
     def title
       'Walgreens'
     end

--- a/lib/sites/zocdoc.rb
+++ b/lib/sites/zocdoc.rb
@@ -141,6 +141,10 @@ module Zocdoc
       @location = location
     end
 
+    def module_name
+      'ZOCDOC'
+    end
+
     def city
       @location['city']
     end

--- a/spec/base_clinic_spec.rb
+++ b/spec/base_clinic_spec.rb
@@ -138,16 +138,4 @@ describe BaseClinic do
       expect(clinic.should_tweet?).to be false
     end
   end
-
-  describe '#module_prefix' do
-    it 'returns the class name in all caps' do
-      clinic = BaseClinic.new(storage)
-      expect(clinic.module_prefix).to eq('BASE_CLINIC')
-    end
-
-    it 'works with subclasses' do
-      clinic = TestClinic.new(storage)
-      expect(clinic.module_prefix).to eq('TEST_CLINIC')
-    end
-  end
 end

--- a/spec/base_clinic_spec.rb
+++ b/spec/base_clinic_spec.rb
@@ -2,6 +2,9 @@ require 'date'
 
 require_relative '../lib/sites/base_clinic'
 
+class TestClinic < BaseClinic
+end
+
 describe BaseClinic do
   let(:redis) { double('Redis') }
   let(:storage) { Storage.new(redis) }
@@ -82,7 +85,7 @@ describe BaseClinic do
       expect(clinic.has_not_posted_recently?).to be true
     end
 
-    it 'returns false if there is a post in the last 10 minutes' do
+    it 'returns false if there is a post in the last 30 minutes' do
       clinic = BaseClinic.new(storage)
       expect(storage).to receive(:get_post_time).with(clinic).and_return((Time.now - 5 * 60).to_s)
       expect(clinic.has_not_posted_recently?).to be false
@@ -133,6 +136,18 @@ describe BaseClinic do
       allow(storage).to receive(:get_appointments).and_return(0)
       allow(storage).to receive(:get_post_time).and_return((Time.now - 60).to_s)
       expect(clinic.should_tweet?).to be false
+    end
+  end
+
+  describe '#module_prefix' do
+    it 'returns the class name in all caps' do
+      clinic = BaseClinic.new(storage)
+      expect(clinic.module_prefix).to eq('BASE_CLINIC')
+    end
+
+    it 'works with subclasses' do
+      clinic = TestClinic.new(storage)
+      expect(clinic.module_prefix).to eq('TEST_CLINIC')
     end
   end
 end


### PR DESCRIPTION
This allows for dynamic environment setting using environment variables based on site module names. For example, `MA_IMMUNIZATIONS_TWEET_THRESHOLD` will control the tweet threshold for just the MaImmunizations module.